### PR TITLE
DuckDB optionally fetched at build time

### DIFF
--- a/.github/workflows/_extension_distribution.yml
+++ b/.github/workflows/_extension_distribution.yml
@@ -76,6 +76,10 @@ on:
         required: false
         type: boolean
         default: false
+
+env:
+  DUCKDB_DEFAULT_VERSION: ${{ inputs.duckdb_version }}
+
 jobs:
   generate_matrix:
     name: Generate matrix
@@ -104,6 +108,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          make duckdb
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
@@ -227,6 +232,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          make duckdb
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
@@ -345,6 +351,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          make duckdb
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
@@ -442,6 +449,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          make duckdb
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 
@@ -510,6 +518,7 @@ jobs:
 
       - name: Checkout DuckDB to version
         run: |
+          make duckdb
           cd duckdb
           git checkout ${{ inputs.duckdb_version }}
 

--- a/makefiles/duckdb_extension.Makefile
+++ b/makefiles/duckdb_extension.Makefile
@@ -60,17 +60,23 @@ EXTENSION_FLAGS=-DDUCKDB_EXTENSION_CONFIGS='${EXT_CONFIG}'
 
 BUILD_FLAGS=-DEXTENSION_STATIC_BUILD=1 $(EXTENSION_FLAGS) ${EXT_FLAGS} $(CORE_EXTENSION_VAR) $(OSX_BUILD_FLAG) $(RUST_FLAGS) $(TOOLCHAIN_FLAGS) -DDUCKDB_EXPLICIT_PLATFORM='${DUCKDB_PLATFORM}' -DCUSTOM_LINKER=${CUSTOM_LINKER}
 
-debug:
+duckdb:
+	git clone https://github.com/duckdb/duckdb --branch $(DUCKDB_DEFAULT_VERSION) || ( echo "git clone failed, check if DUCKDB_DEFAULT_VERSION is defined and able to fetch remote resources" && exit 1 )
+
+duckdb_version: duckdb
+	cd duckdb && git checkout $(DUCKDB_DEFAULT_VERSION)
+
+debug: duckdb_version
 	mkdir -p  build/debug
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_DEBUG_FLAGS) -DCMAKE_BUILD_TYPE=Debug -S $(DUCKDB_SRCDIR) -B build/debug
 	cmake --build build/debug --config Debug
 
-release:
+release: duckdb_version
 	mkdir -p build/release
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DCMAKE_BUILD_TYPE=Release -S $(DUCKDB_SRCDIR) -B build/release
 	cmake --build build/release --config Release
 
-reldebug:
+reldebug: duckdb_version
 	mkdir -p build/reldebug
 	cmake $(GENERATOR) $(BUILD_FLAGS) $(EXT_RELEASE_FLAGS) -DCMAKE_BUILD_TYPE=RelWithDebInfo -S $(DUCKDB_SRCDIR) -B build/reldebug
 	cmake --build build/reldebug
@@ -95,17 +101,17 @@ WASM_CXX_EH_FLAGS=$(WASM_CXX_MVP_FLAGS) -fwasm-exceptions -DWEBDB_FAST_EXCEPTION
 WASM_CXX_THREADS_FLAGS=$(WASM_COMPILE_TIME_EH_FLAGS) -DWITH_WASM_THREADS=1 -DWITH_WASM_SIMD=1 -DWITH_WASM_BULK_MEMORY=1 -pthread
 
 # WASM targets
-wasm_mvp:
+wasm_mvp: duckdb_version
 	mkdir -p build/wasm_mvp
 	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_mvp -DCMAKE_CXX_FLAGS="$(WASM_CXX_MVP_FLAGS)" -S $(DUCKDB_SRCDIR) -DDUCKDB_EXPLICIT_PLATFORM=wasm_mvp -DDUCKDB_CUSTOM_PLATFORM=wasm_mvp
 	emmake make -j8 -Cbuild/wasm_mvp
 
-wasm_eh:
+wasm_eh: duckdb_version
 	mkdir -p build/wasm_eh
 	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_eh -DCMAKE_CXX_FLAGS="$(WASM_CXX_EH_FLAGS)" -S $(DUCKDB_SRCDIR) -DDUCKDB_EXPLICIT_PLATFORM=wasm_eh -DDUCKDB_CUSTOM_PLATFORM=wasm_eh
 	emmake make -j8 -Cbuild/wasm_eh
 
-wasm_threads:
+wasm_threads: duckdb_version
 	mkdir -p ./build/wasm_threads
 	emcmake cmake $(GENERATOR) $(EXTENSION_FLAGS) $(WASM_COMPILE_TIME_COMMON_FLAGS) -Bbuild/wasm_threads -DCMAKE_CXX_FLAGS="$(WASM_CXX_THREADS_FLAGS)" -S $(DUCKDB_SRCDIR) -DDUCKDB_EXPLICIT_PLATFORM=wasm_threads -DDUCKDB_CUSTOM_PLATFORM=wasm_threads
 	emmake make -j8 -Cbuild/wasm_threads


### PR DESCRIPTION
This allows extensions that want to opt-in to move from having duckdb has submodule to having duckdb as a compile-time dependency.

There are no changes needed on existing extensions, but extension that want to opt-in can:
* remove duckdb from the submodules (`git rm duckdb`)
* add a `DUCKDB_DEFAULT_VERSION=v1.0.0` line to the Makefile, that specifies the default version of DuckDB to be compiled against (`v1.0.0` is at the moment latest release, but any other git ref would work the same)
* point to an extension-ci-tools that includes this PR

Example of usage is at https://github.com/duckdb/duckdb_excel/compare/main...carlopi:duckdb_excel:main

Main advantage that I saw is allowing to avoiding having 1 local copy of the duckdb repository for each extension, and offering an easier way to switch DuckDB version, given `DUCKDB_DEFAULT_VERSION=main make` would do the checkout AND build on the newer tag.

Opening the PR for discussion.